### PR TITLE
Fix gps.locate thinking it had a location too soon and returning an incorrect position. Fixes #1

### DIFF
--- a/usr/bin/gps.lua
+++ b/usr/bin/gps.lua
@@ -59,7 +59,7 @@ local function trilaterate(A, B, C)
   end
   local d, ex = len(a2b), norm(a2b)
   local i = dot(ex, a2c)
-  local ey = norm(sub(mul(ex, i), a2c))
+  local ey = norm(sub(a2c, mul(ex, i)))
   local j, ez = dot(ey, a2c), cross(ex, ey)
   local r1, r2, r3 = A.d, B.d, C.d
   local x = (r1^2 - r2^2 + d^2) / (2*d)
@@ -69,7 +69,7 @@ local function trilaterate(A, B, C)
   if zSquared > 0 then
     local z = sqrt( zSquared )
     local result1 = add(result, mul(ez, z))
-    local result2 = add(result, mul(ez, z))
+    local result2 = sub(result, mul(ez, z))
     local rnd1, rnd2 = round(result1, 0.01), round(result2, 0.01)
     if rnd1.x ~= rnd2.x or rnd1.y ~= rnd2.y or rnd1.z ~= rnd2.z then
       return rnd1, rnd2

--- a/usr/lib/gps.lua
+++ b/usr/lib/gps.lua
@@ -58,7 +58,7 @@ local function trilaterate(A, B, C)
   local d = len(a2b)
   local ex = norm(a2b)
   local i = dot(ex, a2c)
-  local ey = norm(sub(mul(ex, i), a2c))
+  local ey = norm(sub(a2c, mul(ex, i)))
   local j = dot(ey, a2c)
   local ez = cross(ex, ey)
   local r1 = A.d
@@ -71,7 +71,7 @@ local function trilaterate(A, B, C)
   if zSquared > 0 then
     local z = sqrt( zSquared )
     local result1 = add(result, mul(ez, z))
-    local result2 = add(result, mul(ez, z))
+    local result2 = sub(result, mul(ez, z))
     local rounded1, rounded2 = round(result1, 0.01), round(result2, 0.01)
     if rounded1.x ~= rounded2.x or
        rounded1.y ~= rounded2.y or


### PR DESCRIPTION
Microcontrollers that were flashed with predetermined coordinates are fine but ones that got their coordinates themselves from other microcontrollers are likely incorrect and will need reflashing.

All other devices will just need an updated /usr/lib/gps.lua